### PR TITLE
Edit Customer backend - VIEW fix

### DIFF
--- a/app/Http/Resources/CustomerResource.php
+++ b/app/Http/Resources/CustomerResource.php
@@ -21,6 +21,30 @@ class CustomerResource extends JsonResource
     {
         $shipping = $this->shippingAddress;
         $billing = $this->billingAddress;
+
+        if($shipping) {
+            $shipping = [
+                'id' => $shipping->id,
+                'address1' => $shipping->address1,
+                'address2' => $shipping->address2,
+                'city' => $shipping->city,
+                'state' => $shipping->state,
+                'zipcode' => $shipping->zipcode,
+                'country_code' => $shipping->country->code,
+            ];
+        }
+        if($billing) {
+            $billing = [
+                'id' => $billing->id,
+                'address1' => $billing->address1,
+                'address2' => $billing->address2,
+                'city' => $billing->city,
+                'state' => $billing->state,
+                'zipcode' => $billing->zipcode,
+                'country_code' => $billing->country->code,
+            ];
+        }
+
         return [
             'id' => $this->user_id,
             'first_name' => $this->first_name,
@@ -31,24 +55,8 @@ class CustomerResource extends JsonResource
             'created_at' => (new \DateTime($this->created_at))->format('Y-m-d H:i:s'),
             'updated_at' => (new \DateTime($this->updated_at))->format('Y-m-d H:i:s'),
 
-            'shippingAddress' => [
-                'id' => $shipping->id,
-                'address1' => $shipping->address1,
-                'address2' => $shipping->address2,
-                'city' => $shipping->city,
-                'state' => $shipping->state,
-                'zipcode' => $shipping->zipcode,
-                'country_code' => $shipping->country->code,
-            ],
-            'billingAddress' => [
-                'id' => $billing->id,
-                'address1' => $billing->address1,
-                'address2' => $billing->address2,
-                'city' => $billing->city,
-                'state' => $billing->state,
-                'zipcode' => $billing->zipcode,
-                'country_code' => $billing->country->code,
-            ]
+            'shippingAddress' => $shipping,
+            'billingAddress' => $billing
         ];
     }
 }

--- a/backend/src/views/Customers/CustomerView.vue
+++ b/backend/src/views/Customers/CustomerView.vue
@@ -14,7 +14,7 @@
           <div>
             <h2 class="text-xl font-semibold mt-6 pb-2 border-b border-gray-300">Billing Address</h2>
 
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
+            <div v-if="customer.billingAddress !== null" class="grid grid-cols-1 md:grid-cols-2 gap-2">
               <CustomInput v-model="customer.billingAddress.address1" label="Address 1"/>
               <CustomInput v-model="customer.billingAddress.address2" label="Address 2"/>
               <CustomInput v-model="customer.billingAddress.city" label="City"/>
@@ -26,12 +26,15 @@
               <CustomInput v-else type="select" :select-options="billingStateOptions"
                            v-model="customer.billingAddress.state" label="State"/>
             </div>
+            <p v-else class="text-center py-8 text-gray-700">
+              There are is no billing address
+            </p>
           </div>
 
           <div>
             <h2 class="text-xl font-semibold mt-6 pb-2 border-b border-gray-300">Shipping Address</h2>
 
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
+            <div v-if="customer.shippingAddress !== null" class="grid grid-cols-1 md:grid-cols-2 gap-2">
               <CustomInput v-model="customer.shippingAddress.address1" label="Address 1"/>
               <CustomInput v-model="customer.shippingAddress.address2" label="Address 2"/>
               <CustomInput v-model="customer.shippingAddress.city" label="City"/>
@@ -42,6 +45,9 @@
               <CustomInput v-else type="select" :select-options="shippingStateOptions"
                            v-model="customer.shippingAddress.state" label="State"/>
             </div>
+            <p v-else class="text-center py-8 text-gray-700">
+              There are is no shipping address
+            </p>
           </div>
         </div>
 


### PR DESCRIPTION

![edit customer fix](https://user-images.githubusercontent.com/73112613/208435927-42031431-5bff-47d4-a55b-028bc1f59e3c.png)
Hey, I've fixed the Edit customer view which was throwing an error if there is no billing or shipping information attached to the customer. 
Can you have a look ?



Commit MSG: 
CustomerResource response changed.
Backend customer edit view changed to show that there is no billing or shipping inforamtion if there is no any.