### PR TITLE
Prevent admin from login on user site

### DIFF
--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -46,7 +46,9 @@ class LoginRequest extends FormRequest
     {
         $this->ensureIsNotRateLimited();
 
-        if (!Auth::attempt($this->only('email', 'password'), $this->boolean('remember'))) {
+        $credentials = $this->only('email', 'password');
+        $credentials['is_admin'] = 0;
+        if (!Auth::attempt($credentials, $this->boolean('remember'))) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([


### PR DESCRIPTION
Hi! I have tried to log in to admin from the user site and encountered the following error.

![Screenshot_20230410_005124](https://user-images.githubusercontent.com/25638019/230793968-23637874-eb34-4403-8528-76fb1ec00f1a.png)

So, what's happening, is that there is no check that the user who tries to log in from the user side should not be admin. I have added it.
